### PR TITLE
Add statnet/rle to Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,3 +16,5 @@ RoxygenNote: 7.1.0
 Encoding: UTF-8
 Suggests: 
     covr
+Remotes: 
+    statnet/rle


### PR DESCRIPTION
This would allow https://github.com/statnet/network/pull/20 to build until `{rle}` makes it to CRAN.